### PR TITLE
Do not generate empty asset files

### DIFF
--- a/app/assets/javascripts/spree/backend/solidus_wallet_backport.js
+++ b/app/assets/javascripts/spree/backend/solidus_wallet_backport.js
@@ -1,2 +1,0 @@
-// Placeholder manifest file.
-// the installer will append this file to the app vendored assets here: vendor/assets/javascripts/spree/backend/all.js'

--- a/app/assets/javascripts/spree/frontend/solidus_wallet_backport.js
+++ b/app/assets/javascripts/spree/frontend/solidus_wallet_backport.js
@@ -1,2 +1,0 @@
-// Placeholder manifest file.
-// the installer will append this file to the app vendored assets here: vendor/assets/javascripts/spree/frontend/all.js'

--- a/app/assets/stylesheets/spree/backend/solidus_wallet_backport.css
+++ b/app/assets/stylesheets/spree/backend/solidus_wallet_backport.css
@@ -1,4 +1,0 @@
-/*
-Placeholder manifest file.
-the installer will append this file to the app vendored assets here: 'vendor/assets/stylesheets/spree/backend/all.css'
-*/

--- a/app/assets/stylesheets/spree/frontend/solidus_wallet_backport.css
+++ b/app/assets/stylesheets/spree/frontend/solidus_wallet_backport.css
@@ -1,4 +1,0 @@
-/*
-Placeholder manifest file.
-the installer will append this file to the app vendored assets here: 'vendor/assets/stylesheets/spree/frontend/all.css'
-*/

--- a/lib/generators/solidus_wallet_backport/install/install_generator.rb
+++ b/lib/generators/solidus_wallet_backport/install/install_generator.rb
@@ -3,16 +3,6 @@ module SolidusWalletBackport
     class InstallGenerator < Rails::Generators::Base
       class_option :auto_run_migrations, type: :boolean, default: false
 
-      def add_javascripts
-        append_file 'vendor/assets/javascripts/spree/frontend/all.js', "//= require spree/frontend/solidus_wallet_backport\n"
-        append_file 'vendor/assets/javascripts/spree/backend/all.js', "//= require spree/backend/solidus_wallet_backport\n"
-      end
-
-      def add_stylesheets
-        inject_into_file 'vendor/assets/stylesheets/spree/frontend/all.css', " *= require spree/frontend/solidus_wallet_backport\n", before: /\*\//, verbose: true
-        inject_into_file 'vendor/assets/stylesheets/spree/backend/all.css', " *= require spree/backend/solidus_wallet_backport\n", before: /\*\//, verbose: true
-      end
-
       def add_migrations
         run 'bundle exec rake railties:install:migrations FROM=solidus_wallet_backport'
       end


### PR DESCRIPTION
We do not ship any javascript with this gem. We should not generate
empty asset manifests into the host app that only load empty files.